### PR TITLE
Add more one line for TDS/EY to items of list view

### DIFF
--- a/app/views/shots/_shot.html.slim
+++ b/app/views/shots/_shot.html.slim
@@ -6,6 +6,8 @@
 - bean_weight = shot.bean_weight.to_f
 - drink_weight = shot.drink_weight.to_f
 - ratio = drink_weight / bean_weight
+- tds = shot.drink_tds.to_f
+- ey = shot.drink_ey.to_f
 
 tr.cursor-pointer id=dom_id(shot) data-action="click->shot#view" data-url=shot_path(shot)
   td.py-4.px-1.sm:px-4
@@ -67,6 +69,17 @@ tr.cursor-pointer id=dom_id(shot) data-action="click->shot#view" data-url=shot_p
         - if shot.grinder_setting.present?
           ' @
           = shot.grinder_setting
+      span.text-sm.text-stone-500.dark:text-stone-400
+        - if tds > 0
+          ' TDS
+          = tds
+          ' %
+        - if tds > 0 && ey > 0
+          '
+        - if ey > 0
+          ' EY
+          = ey
+          ' %
   td.py-4.px-1.sm:px-4
     .flex.flex-col.lg:flex-row
       .grow


### PR DESCRIPTION
Closes #46. This PR adds extra line for TDS/EY to items of list view. The format of data was borrowed from the shot detail view. I considered that I should refactor something like shared helpers for calculating TDS/EY, but other values (e.g. `ratio`) are simply written, so I did nothing at this time.

![Screenshot from 2022-01-16 18-34-01](https://user-images.githubusercontent.com/151614/149654603-f51d5056-93dc-40eb-b8a4-741751bdd3dc.png)
