### PR TITLE
Adding labels for weight in cup at the stage transitions

### DIFF
--- a/app/javascript/charts/shot.js
+++ b/app/javascript/charts/shot.js
@@ -1,4 +1,5 @@
 import Highcharts from "highcharts"
+import "highcharts-annotations"
 
 Highcharts.wrap(Highcharts.Chart.prototype, "zoom", function (proceed) {
   proceed.apply(this, [].slice.call(arguments, 1))
@@ -187,8 +188,41 @@ function commonOptions() {
   }
 }
 
+function extractStages(field, timings) {
+    for (let i = 0; i < window.shotData.length; i++) {
+        let data = window.shotData[i];
+        if (data.name == field) {
+            return data.data.filter((x) => timings.includes(x[0])).map((x) => x[1])
+        }
+    }
+
+    // If the series is not present, assume all 0
+    return timings.map(_ => 0)
+}
+
 function drawShotChart() {
   const colors = getColors()
+
+  const timings = shotStages.map(x => x.value)
+  const weightFlow = extractStages("Weight Flow", timings)
+  const weight = extractStages("Weight", timings)
+  const annotations = timings.map((timing, index) => {
+    const inCup = weight[index]
+    return {
+      visible: inCup > 0,
+      labels: [
+        {
+          text: `${inCup}g in cup`,
+          point: {"x": timing, "y": weightFlow[index], "xAxis": 0, "yAxis": 0}
+        }
+      ],
+      labelOptions: {
+        shape: "connector",
+        align: "right",
+        y: -50
+      }
+    }
+  })
 
   const custom = {
     chart: {
@@ -196,6 +230,7 @@ function drawShotChart() {
       height: window.chartHeight,
       backgroundColor: colors.background
     },
+    annotations: annotations,
     series: window.shotData
   }
 

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -9,6 +9,7 @@ pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
 pin "stimulus-autocomplete", to: "https://cdn.jsdelivr.net/npm/stimulus-autocomplete@3.0.1/src/autocomplete.js"
 pin "el-transition", to: "https://cdn.jsdelivr.net/npm/el-transition@0.0.7/index.js"
 pin "highcharts", to: "https://cdn.jsdelivr.net/npm/highcharts@9.3.2/es-modules/masters/highcharts.src.js"
+pin "highcharts-annotations", to: "https://cdn.jsdelivr.net/npm/highcharts@9.3.2/es-modules/masters/modules/annotations.src.js"
 
 pin_all_from "app/javascript/channels", under: "channels"
 pin_all_from "app/javascript/controllers", under: "controllers"


### PR DESCRIPTION
This simple call-out at the intersection of the weight flow line and the stage transitions. It allows to quickly answer the common question of how much has dripped at the end of the preinfusion.

The alternative is to add the total weight line and attempt to see where it crosses. However, doing so changes the graphs scale.