### PR TITLE
Move JSONB information out of Shot

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,12 @@ Style/HashSyntax:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
+Style/SymbolArray:
+  Enabled: true
+
+Style/WordArray:
+  Enabled: true
+
 Rails/I18nLocaleTexts:
   Enabled: false
 

--- a/app/controllers/api/shots_controller.rb
+++ b/app/controllers/api/shots_controller.rb
@@ -82,6 +82,10 @@ module Api
     def with_shot
       shot = Shot.find_by(id: params[:shot_id])
       if shot
+        if shot.information.nil? # TODO: DELETE THIS
+          ShotInformation.from_shot(shot)
+          shot.reload
+        end
         yield(shot)
       else
         render json: {error: "Shot not found"}, status: :not_found

--- a/app/controllers/api/shots_controller.rb
+++ b/app/controllers/api/shots_controller.rb
@@ -36,8 +36,8 @@ module Api
 
     def profile
       with_shot do |shot|
-        if shot.tcl_profile_fields.present?
-          send_file shot.tcl_profile, filename: "#{shot.profile_title} from Visualizer.tcl", type: "application/x-tcl", disposition: "attachment"
+        if shot.information.tcl_profile_fields.present?
+          send_file shot.information.tcl_profile, filename: "#{shot.profile_title} from Visualizer.tcl", type: "application/x-tcl", disposition: "attachment"
         else
           render json: {error: "Shot does not have a profile"}, status: :unprocessable_entity
         end
@@ -93,12 +93,15 @@ module Api
 
       allowed_attrs = %w[id profile_title user_id drink_tds drink_ey espresso_enjoyment bean_weight drink_weight grinder_model grinder_setting bean_brand bean_type roast_date espresso_notes roast_level bean_notes]
       allowed_attrs += %w[start_time] unless shot.user&.hide_shot_times
-      allowed_attrs += %w[timeframe data] if with_data
       json = shot.attributes.slice(*allowed_attrs)
+      if with_data
+        json[:timeframe] = shot.information.timeframe
+        json[:data] = shot.information.data
+      end
       json[:duration] = shot.duration
       json[:user_name] = shot.user.display_name if shot.user&.public?
       json[:image_preview] = shot.screenshot_url if shot.screenshot?
-      json[:profile_url] = api_shot_profile_url(shot) if shot.tcl_profile_fields.present?
+      json[:profile_url] = api_shot_profile_url(shot) if shot.information.tcl_profile_fields.present?
       json
     end
   end

--- a/app/models/shot.rb
+++ b/app/models/shot.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Shot < ApplicationRecord
-  self.ignored_columns += %i[data extra profile_fields timeframe]
-
   SCREENSHOTS_URL = "https://visualizer-coffee-shots.s3.eu-central-1.amazonaws.com"
   DATA_LABELS = %w[espresso_pressure espresso_weight espresso_flow espresso_flow_weight espresso_temperature_basket espresso_temperature_mix espresso_water_dispensed espresso_temperature_goal espresso_flow_weight_raw espresso_pressure_goal espresso_flow_goal espresso_resistance espresso_resistance_weight espresso_state_change].freeze
   EXTRA_DATA_METHODS = %w[drink_weight grinder_model grinder_setting bean_brand bean_type roast_level roast_date drink_tds drink_ey espresso_enjoyment espresso_notes bean_notes].freeze

--- a/app/models/shot_chart.rb
+++ b/app/models/shot_chart.rb
@@ -127,7 +127,10 @@ class ShotChart
   end
 
   def process_data(shot, label_suffix: nil)
-    shot.information ||= ShotInformation.from_shot(shot) # TODO: DELETE THIS
+    if shot.information.nil? # TODO: DELETE THIS
+      ShotInformation.from_shot(shot)
+      shot.reload
+    end
     timeframe = shot.information.timeframe
     timeframe_count = timeframe.count
     timeframe_last = timeframe.last.to_f

--- a/app/models/shot_chart.rb
+++ b/app/models/shot_chart.rb
@@ -28,7 +28,7 @@ class ShotChart
   end
 
   memoize def stages
-    indices = shot.data.key?("espresso_state_change") ? stages_from_state_change(shot.data["espresso_state_change"]) : detect_stages_from_data(shot.data)
+    indices = shot.information.data.key?("espresso_state_change") ? stages_from_state_change(shot.information.data["espresso_state_change"]) : detect_stages_from_data(shot.information.data)
     processed_shot_data.first.second.values_at(*indices).map { |d| {value: d.first} }
   end
 
@@ -127,12 +127,13 @@ class ShotChart
   end
 
   def process_data(shot, label_suffix: nil)
-    timeframe = shot.timeframe
+    shot.information ||= ShotInformation.from_shot(shot) # TODO: DELETE THIS
+    timeframe = shot.information.timeframe
     timeframe_count = timeframe.count
     timeframe_last = timeframe.last.to_f
     timeframe_diff = (timeframe_last + timeframe.first.to_f) / timeframe.count.to_f
-    in_fahrenheit = shot.fahrenheit?
-    shot.data.filter_map do |label, data|
+    in_fahrenheit = shot.information.fahrenheit?
+    shot.information.data.filter_map do |label, data|
       next if DATA_LABELS_TO_IGNORE.include?(label)
 
       times10 = label == "espresso_water_dispensed"

--- a/app/models/shot_information.rb
+++ b/app/models/shot_information.rb
@@ -1,0 +1,103 @@
+class ShotInformation < ApplicationRecord
+  JSON_PROFILE_KEYS = %w[title author notes beverage_type steps tank_temperature target_weight target_volume target_volume_count_start legacy_profile_type type lang hidden reference_file changes_since_last_espresso version].freeze
+
+  extend Memoist
+
+  belongs_to :shot
+
+  def self.from_shot(shot)
+    ActiveRecord::Base.transaction do
+      columns = column_names - %w[id shot_id]
+      shot = Shot.where(id: shot.id).select(["id"] + columns).first
+      information = ShotInformation.new(shot_id: shot["id"])
+      columns.each do |column|
+        information[column] = shot[column]
+      end
+      information.save!
+      information
+    end
+  end
+
+  def fahrenheit?
+    extra["enable_fahrenheit"].to_i == 1
+  end
+
+  def calculate_duration
+    index = [data["espresso_flow"].size, timeframe.size].min
+    timeframe[index - 1].to_f
+  end
+
+  memoize def extra
+    super.presence || {}
+  end
+
+  memoize def profile_fields
+    super.presence || {}
+  end
+
+  memoize def tcl_profile_fields
+    profile_fields.except("json")
+  end
+
+  memoize def json_profile_fields
+    profile_fields["json"]
+  end
+
+  def tcl_profile
+    return if tcl_profile_fields.blank?
+
+    content = tcl_profile_fields.to_a.sort_by(&:first).map do |k, v|
+      v = "Visualizer/#{v}" if k == "profile_title"
+      v = "#{v}\n\nDownloaded from Visualizer" if k == "profile_notes"
+      v = "{}" if v.blank?
+      v = "{#{v}}" if /\w\s\w/.match?(v)
+
+      "#{k} #{v}"
+    end
+
+    file_from_content(["#{shot.profile_title} from Visualizer", ".tcl"], content.join("\n"))
+  end
+
+  def json_profile
+    return if json_profile_fields.blank?
+
+    json = {}
+    JSON_PROFILE_KEYS.each do |key|
+      v = profile_fields["json"][key]
+      v = "Visualizer/#{v}" if key == "title"
+      v = "#{v}\n\nDownloaded from Visualizer" if key == "notes"
+      json[key] = v
+    end
+
+    JSON.pretty_generate(json)
+  end
+
+  private
+
+  def file_from_content(filename, content)
+    file = Tempfile.new(filename)
+    file.write(content)
+    file.close
+    file.path
+  end
+end
+
+# == Schema Information
+#
+# Table name: shot_informations
+#
+#  id             :uuid             not null, primary key
+#  data           :jsonb
+#  extra          :jsonb
+#  profile_fields :jsonb
+#  timeframe      :jsonb
+#  shot_id        :uuid             not null
+#
+# Indexes
+#
+#  index_shot_informations_on_shot_id  (shot_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (shot_id => shots.id)
+#

--- a/app/models/shot_information.rb
+++ b/app/models/shot_information.rb
@@ -10,13 +10,10 @@ class ShotInformation < ApplicationRecord
   def self.from_shot(shot)
     return if exists?(shot_id: shot.id)
 
-    columns = ["data", "extra", "profile_fields", "timeframe"]
-    nullified = columns.index_with { |c| nil }
     ActiveRecord::Base.transaction do
       information = {shot_id: shot["id"]}
-      columns.each { |column| information[column] = shot[column] }
+      Shot::INFORMATION_KEYS.each { |column| information[column] = shot[column] }
       ShotInformation.insert!(information) # rubocop:disable Rails/SkipsModelValidations
-      Shot.find(shot["id"]).update_columns(nullified) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 

--- a/app/views/shots/show.html.slim
+++ b/app/views/shots/show.html.slim
@@ -1,5 +1,5 @@
 - owner = current_user && @shot.user_id == current_user.id
-- show_header = owner || @shot.user&.public? || @shot.tcl_profile_fields.present?
+- show_header = owner || @shot.user&.public? || @shot.information.tcl_profile_fields.present?
 - show_owner_info = !owner && @shot.user&.public?
 
 - content_for :meta_tags
@@ -27,7 +27,7 @@
               = link_to premium_index_path do
                 svg.ml-1.mt-1.h-9.w-9.text-pink-600.hover:text-pink-800 xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor"
                   path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
-        - if @shot.tcl_profile_fields.present?
+        - if @shot.information.tcl_profile_fields.present?
           .flex
             = render "share", shot: @shot
             = render "related_shots", related_shots: @related_shots, shot: @shot if @related_shots.present?
@@ -58,7 +58,7 @@
                 = button_to shot_path, method: :delete, form_class: "inline-flex", class: "inline-flex px-4 py-2 border border-stone-300 dark:border-stone-600 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white dark:bg-stone-800 dark:text-stone-300 hover:bg-red-50 dark:hover:bg-red-900", data: {action: "click->modal#confirm", title: "Delete Shot", text: "Are you sure you want to permanently delete shot from #{@shot.start_time.in_time_zone(@timezone).to_formatted_s(:long)}?"} do
                   svg.-ml-1.-mr-1.h-4.w-4.text-stone-500.dark:text-stone-300 xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor"
                     path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd"
-            - if @shot.tcl_profile_fields.present?
+            - if @shot.information.tcl_profile_fields.present?
               = render "share", shot: @shot
           - if owner && @related_shots.present?
             .grow

--- a/db/migrate/20221004091352_create_shot_informations.rb
+++ b/db/migrate/20221004091352_create_shot_informations.rb
@@ -1,0 +1,11 @@
+class CreateShotInformations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :shot_informations, id: :uuid do |t|
+      t.references :shot, null: false, foreign_key: true, type: :uuid
+      t.jsonb :data
+      t.jsonb :extra
+      t.jsonb :profile_fields
+      t.jsonb :timeframe
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_10_04_084040) do
+ActiveRecord::Schema[7.0].define(version: 2022_10_04_091352) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -109,6 +109,15 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_084040) do
     t.index ["user_id"], name: "index_shared_shots_on_user_id"
   end
 
+  create_table "shot_informations", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "shot_id", null: false
+    t.jsonb "data"
+    t.jsonb "extra"
+    t.jsonb "profile_fields"
+    t.jsonb "timeframe"
+    t.index ["shot_id"], name: "index_shot_informations_on_shot_id"
+  end
+
   create_table "shots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.datetime "start_time", precision: nil
     t.jsonb "data"
@@ -180,5 +189,6 @@ ActiveRecord::Schema[7.0].define(version: 2022_10_04_084040) do
   add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "shared_shots", "shots"
   add_foreign_key "shared_shots", "users"
+  add_foreign_key "shot_informations", "shots"
   add_foreign_key "shots", "users"
 end

--- a/lib/tasks/shots.rake
+++ b/lib/tasks/shots.rake
@@ -5,15 +5,12 @@ namespace :shots do
     missing = Shot.pluck(:id) - ShotInformation.pluck(:shot_id)
     puts "Filling data for #{missing.count} shots"
     i = 0
-    columns = %w[data extra profile_fields timeframe]
-    nullified = columns.index_with { |c| nil }
-    attrs = ["id"] + columns
-    info_attrs = ["shot_id"] + columns
+    attrs = ["id"] + Shot::INFORMATION_KEYS
+    info_attrs = ["shot_id"] + Shot::INFORMATION_KEYS
     missing.in_groups_of(100, false) do |group|
       ActiveRecord::Base.transaction do
         informations = Shot.where(id: group).pluck(*attrs).map { |s| info_attrs.zip(s).to_h }
         ShotInformation.insert_all!(informations) # rubocop:disable Rails/SkipsModelValidations
-        Shot.where(id: group).update_all(nullified) # rubocop:disable Rails/SkipsModelValidations
       end
 
       i += group.size

--- a/lib/tasks/shots.rake
+++ b/lib/tasks/shots.rake
@@ -5,7 +5,7 @@ namespace :shots do
     missing = Shot.pluck(:id) - ShotInformation.pluck(:shot_id)
     puts "Filling data for #{missing.count} shots"
     i = 0
-    Shot.find_each do |shot|
+    Shot.where(id: missing).find_each do |shot|
       next unless missing.include?(shot.id)
 
       ShotInformation.from_shot(shot)

--- a/lib/tasks/shots.rake
+++ b/lib/tasks/shots.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :shots do
+  task copy_data: :environment do
+    missing = Shot.pluck(:id) - ShotInformation.pluck(:shot_id)
+    puts "Filling data for #{missing.count} shots"
+    i = 0
+    Shot.find_each do |shot|
+      next unless missing.include?(shot.id)
+
+      ShotInformation.from_shot(shot)
+      i += 1
+      puts "#{i} done" if (i % 1000).zero?
+    end
+  end
+end

--- a/test/models/shot_test.rb
+++ b/test/models/shot_test.rb
@@ -9,13 +9,13 @@ class ShotTest < ActiveSupport::TestCase
     assert_equal users(:miha), shot.user
     assert_equal "JoeD's Easy blooming slow ramp to 7 bar", shot.profile_title
     assert_equal "2021-09-21 06:59:10", shot.start_time.to_fs(:db)
-    assert_equal 100, shot.timeframe.size
-    assert_equal "0.044", shot.timeframe.first
-    assert_equal "24.793", shot.timeframe.last
+    assert_equal 100, shot.information.timeframe.size
+    assert_equal "0.044", shot.information.timeframe.first
+    assert_equal "24.793", shot.information.timeframe.last
     assert_equal 24.793, shot.duration
-    assert_equal Shot::DATA_LABELS.sort, shot.data.keys.sort
-    assert_equal 101, shot.data["espresso_pressure"].size
-    assert_equal 16, shot.extra.keys.size
+    assert_equal Shot::DATA_LABELS.sort, shot.information.data.keys.sort
+    assert_equal 101, shot.information.data["espresso_pressure"].size
+    assert_equal 16, shot.information.extra.keys.size
     assert_equal "38.8", shot.drink_weight
     assert_equal "EK43 with SSP HU", shot.grinder_model
     assert_equal "2.1", shot.grinder_setting
@@ -28,13 +28,13 @@ class ShotTest < ActiveSupport::TestCase
     assert_equal 70, shot.espresso_enjoyment
     assert_equal "Neat.", shot.espresso_notes
     assert_equal "With BPlus", shot.bean_notes
-    assert_equal "Miha Rekar", shot.extra["my_name"]
+    assert_equal "Miha Rekar", shot.information.extra["my_name"]
     assert_equal "Miha Rekar", shot.barista
-    assert_equal "MimojaCafe", shot.extra["skin"]
-    # FileUtils.cp(shot.tcl_profile, "#{path}.tcl")
-    assert_equal File.read("#{path}.tcl"), File.read(shot.tcl_profile)
-    # File.write("#{path}.json", shot.json_profile)
-    assert_equal File.read("#{path}.json"), shot.json_profile
+    assert_equal "MimojaCafe", shot.information.extra["skin"]
+    # FileUtils.cp(shot.information.tcl_profile, "#{path}.tcl")
+    assert_equal File.read("#{path}.tcl"), File.read(shot.information.tcl_profile)
+    # File.write("#{path}.json", shot.information.json_profile)
+    assert_equal File.read("#{path}.json"), shot.information.json_profile
   end
 
   test "extracts fields from .json upload file and replaces content when .shot of same shot" do
@@ -43,14 +43,14 @@ class ShotTest < ActiveSupport::TestCase
     assert_equal users(:miha), shot.user
     assert_equal "Easy blooming - active pressure decline", shot.profile_title
     assert_equal "2021-10-19 08:07:44", shot.start_time.to_fs(:db)
-    assert_equal 109, shot.timeframe.size
-    assert_equal "0.044", shot.timeframe.first
-    assert_equal "26.999", shot.timeframe.last
+    assert_equal 109, shot.information.timeframe.size
+    assert_equal "0.044", shot.information.timeframe.first
+    assert_equal "26.999", shot.information.timeframe.last
     assert_equal 26.999, shot.duration
-    assert_equal Shot::DATA_LABELS.sort, shot.data.keys.sort
-    assert_equal 110, shot.data["espresso_pressure"].size
-    assert_equal 18, shot.extra.keys.size
-    assert_equal 46, shot.profile_fields.keys.size
+    assert_equal Shot::DATA_LABELS.sort, shot.information.data.keys.sort
+    assert_equal 110, shot.information.data["espresso_pressure"].size
+    assert_equal 18, shot.information.extra.keys.size
+    assert_equal 46, shot.information.profile_fields.keys.size
     assert_equal "42.6", shot.drink_weight
     assert_equal "EK43 with SSP HU", shot.grinder_model
     assert_equal "2.4", shot.grinder_setting
@@ -63,11 +63,11 @@ class ShotTest < ActiveSupport::TestCase
     assert_equal 0, shot.espresso_enjoyment
     assert_nil shot.espresso_notes
     assert_equal "With BPlus", shot.bean_notes
-    assert_equal "Miha Rekar", shot.extra["my_name"]
+    assert_equal "Miha Rekar", shot.information.extra["my_name"]
     assert_equal "Miha Rekar", shot.barista
-    assert_equal "MimojaCafe", shot.extra["skin"]
-    assert_equal File.read("#{path}.tcl"), File.read(shot.tcl_profile)
-    assert_equal File.read("#{path}.json_profile"), shot.json_profile
+    assert_equal "MimojaCafe", shot.information.extra["skin"]
+    assert_equal File.read("#{path}.tcl"), File.read(shot.information.tcl_profile)
+    assert_equal File.read("#{path}.json_profile"), shot.information.json_profile
 
     shot.save!
     old_id = shot.id
@@ -78,14 +78,14 @@ class ShotTest < ActiveSupport::TestCase
     assert_equal users(:miha), shot.user
     assert_equal "Easy blooming - active pressure decline", shot.profile_title
     assert_equal "2021-10-19 08:07:44", shot.start_time.to_fs(:db)
-    assert_equal 109, shot.timeframe.size
-    assert_equal "0.044", shot.timeframe.first
-    assert_equal "26.999", shot.timeframe.last
+    assert_equal 109, shot.information.timeframe.size
+    assert_equal "0.044", shot.information.timeframe.first
+    assert_equal "26.999", shot.information.timeframe.last
     assert_equal 26.999, shot.duration
-    assert_equal Shot::DATA_LABELS.sort, shot.data.keys.sort
-    assert_equal 110, shot.data["espresso_pressure"].size
-    assert_equal 16, shot.extra.keys.size
-    assert_equal 46, shot.profile_fields.keys.size
+    assert_equal Shot::DATA_LABELS.sort, shot.information.data.keys.sort
+    assert_equal 110, shot.information.data["espresso_pressure"].size
+    assert_equal 16, shot.information.extra.keys.size
+    assert_equal 46, shot.information.profile_fields.keys.size
     assert_equal "42.6", shot.drink_weight
     assert_equal "EK43 with SSP HU", shot.grinder_model
     assert_equal "2.4", shot.grinder_setting
@@ -98,35 +98,35 @@ class ShotTest < ActiveSupport::TestCase
     assert_equal 80, shot.espresso_enjoyment
     assert_nil shot.espresso_notes
     assert_equal "With BPlus", shot.bean_notes
-    assert_equal "Miha Rekar", shot.extra["my_name"]
+    assert_equal "Miha Rekar", shot.information.extra["my_name"]
     assert_equal "Miha Rekar", shot.barista
-    assert_equal "MimojaCafe", shot.extra["skin"]
-    assert_equal File.read("#{path}.tcl"), File.read(shot.tcl_profile)
-    assert_equal File.read("#{path}.json_profile"), shot.json_profile
+    assert_equal "MimojaCafe", shot.information.extra["skin"]
+    assert_equal File.read("#{path}.tcl"), File.read(shot.information.tcl_profile)
+    assert_equal File.read("#{path}.json_profile"), shot.information.json_profile
   end
 
   test "extracts the non-zero bean weight" do
     path = "test/fixtures/files/dsx_weight"
     shot = Shot.from_file(users(:miha), "#{path}.shot")
     assert_equal 18.0, shot.bean_weight.to_f
-    assert_equal File.read("#{path}.tcl"), File.read(shot.tcl_profile)
-    assert_equal File.read("#{path}.json"), shot.json_profile
+    assert_equal File.read("#{path}.tcl"), File.read(shot.information.tcl_profile)
+    assert_equal File.read("#{path}.json"), shot.information.json_profile
   end
 
   test "handles invalid machine string" do
     path = "test/fixtures/files/invalid_machine"
     shot = Shot.from_file(users(:miha), "#{path}.shot")
     assert_equal "Cremina lever machine", shot.profile_title
-    assert_equal File.read("#{path}.tcl"), File.read(shot.tcl_profile)
-    assert_equal File.read("#{path}.json"), shot.json_profile
+    assert_equal File.read("#{path}.tcl"), File.read(shot.information.tcl_profile)
+    assert_equal File.read("#{path}.json"), shot.information.json_profile
   end
 
   test "handles brackets in advanced steps" do
     path = "test/fixtures/files/brackets"
     shot = Shot.from_file(users(:miha), "#{path}.shot")
     assert_equal "manual 82", shot.profile_title
-    assert_equal File.read("#{path}.tcl"), File.read(shot.tcl_profile)
-    assert_equal File.read("#{path}.json"), shot.json_profile
+    assert_equal File.read("#{path}.tcl"), File.read(shot.information.tcl_profile)
+    assert_equal File.read("#{path}.json"), shot.information.json_profile
   end
 
   test "handles invalid profile string" do


### PR DESCRIPTION
Step 1 is to duplicate all the data in ShotInformation and copy all existing data.

Then monitor.

If all is going well, then we can drop the columns and simplify the Shot table significantly. Mainly its size.